### PR TITLE
Always pass tuples to % when using %r.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Marc Abramowitz
 Rob Eanes
 Robert Eanes
 Sundar Raman
+Erik Rose

--- a/pyelasticsearch.py
+++ b/pyelasticsearch.py
@@ -224,7 +224,7 @@ class ElasticSearch(object):
         try:
             return json.dumps(body)
         except (TypeError, json.JSONDecodeError), e:
-            raise ElasticSearchError('Invalid JSON %r' % body, e)
+            raise ElasticSearchError('Invalid JSON %r' % (body,), e)
 
     def _prep_response(self, response):
         """
@@ -233,9 +233,9 @@ class ElasticSearch(object):
         try:
             json_response = response.json
         except (TypeError, json.JSONDecodeError), e:
-            raise ElasticSearchError('Invalid JSON %r' % response, e)
+            raise ElasticSearchError('Invalid JSON %r' % (response,), e)
         if json_response is None:
-            raise ElasticSearchError('Invalid JSON %r' % response)
+            raise ElasticSearchError('Invalid JSON %r' % (response,))
         return json_response
 
     def _query_call(self, query_type, query, body=None, indexes=None,


### PR DESCRIPTION
When a string takes a single substitution, like `'%r' % smoo`, it throws a "TypeError: not all arguments converted during string formatting" in the case that smoo is a tuple of the wrong length. This could easily happen in these spots here, since we're reporting on mysterious, bad input.
