### PR TITLE
Add open_index, close_index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 MANIFEST
 .tox
+*.egg

--- a/pyelasticsearch.py
+++ b/pyelasticsearch.py
@@ -173,6 +173,10 @@ class ElasticSearch(object):
         return path
 
     def _concat(self, items):
+        """
+        Return a comma-delimited concatenation of the elements of ``items``,
+        with any occurrences of "_all" omitted.
+        """
         if items is None:
             return ''
         return ','.join([item for item in items if item != '_all'])
@@ -427,6 +431,21 @@ class ElasticSearch(object):
         Open an index.
         """
         return self._send_index_request('POST', 'Open', index, more_path=['_open'], quiet=quiet)
+
+    def update_settings(self, indexes, settings, quiet=True):
+        """
+        :arg indexes: The indexes to update, or ['_all'] to do all of them
+        """
+        # TODO: Have a way of saying "all indexes" that doesn't involve a magic string.
+        # If we implement the "update cluster settings" API, call that
+        # update_cluster_settings().
+        return self._send_index_request(
+            'PUT',
+            'Settings update on',
+            self._concat(indexes),
+            more_path=['_settings'],
+            quiet=quiet,
+            body=settings)
 
     def flush(self, indexes=None, refresh=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     install_requires=[
         'requests>=0.9.0',
     ],
+    tests_require=['mock'],
     test_suite='tests',
     url='http://github.com/rhec/pyelasticsearch'
 )


### PR DESCRIPTION
Here are a couple methods I needed that weren't there yet. And a hello:

Thanks for this project! I've been using ES for a couple of years now—at Mozilla and now at Votizen, and I helped put together elasticutils, a higher-level ES lib. In my current project, something lower-level is called for, but I find neither pyelasticsearch nor pyes 100% suitable. However, pyelasticsearch has the important advantage of not driving me crazy when I try to hack on it. :-) So here we are.

There are a lot of (what I consider) improvements to pyelasticsearch I'd like to make, and I'd value your feedback beforehand so I know whether to run off on my own or try to work them into pyelasticsearch:
- I wonder what the origin of the `quiet` kwargs is. It seems strange for the default behavior to be basically swallowing errors. Does someone find it more convenient to check the contents of the returned dicts than to catch exceptions?
- Relatedly, I'd like to make the exceptions finer-grained so there are, for example, different ones for a programming error like bad JSON and for an environmental error like a failed connection. They could all subclass ElasticSearchError for backward compatibility.
- I'd like to stop calling ES in most of the tests. It'd be a better test to see if the request output is correct rather than, as many cases do now, just seeing whether ES acknowledged the command.
- I'd like to add the update_settings call (nearly done).
- I'd like to add the ability to target connections at any of a list of ES nodes, like in pyes. We have a decent-sized cluster, and targeting just a single URL either means we need a fancy load balancer in front of it or we sacrifice the high availability advantage of a cluster.

To a first order, are these the sorts of directions you're interested in?

Thanks again!
