### PR TITLE
Compatibility with Python stdlib / simplejson<2.1

### DIFF
--- a/pyelasticsearch.py
+++ b/pyelasticsearch.py
@@ -223,7 +223,7 @@ class ElasticSearch(object):
         """
         try:
             return json.dumps(body)
-        except (TypeError, json.JSONDecodeError), e:
+        except (TypeError, ValueError), e:
             raise ElasticSearchError('Invalid JSON %r' % (body,), e)
 
     def _prep_response(self, response):
@@ -232,7 +232,7 @@ class ElasticSearch(object):
         """
         try:
             json_response = response.json
-        except (TypeError, json.JSONDecodeError), e:
+        except (TypeError, ValueError), e:
             raise ElasticSearchError('Invalid JSON %r' % (response,), e)
         if json_response is None:
             raise ElasticSearchError('Invalid JSON %r' % (response,))


### PR DESCRIPTION
pyelasticsearch.py has two exception handlers which catch json.JSONDecodeError.
Unfortunately, that was only added in simplejson 2.1.0 and because the import
uses the requests.compat.json failover mechanism it's easy to install and use
pyelasticsearch without having installed simplejson 2.1.0, which will produce
unexpected AttributeErrors.

A quick test shows that the stdlib json module in Python 2.6, 2.7 and 3.2
lacks the JSONDecodeError.
