### PR TITLE
Bump requests version requirement so it actually works. Fixes #30.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.0 (unreleased)
+----------------
+
+* Correct the `requests` requirement to require a version that has everything
+  we need.
+
 v0.2 (2012-10-06)
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
     ],
-    requires=[
-        'requests(>=0.9.0)',
+    requires=[  # Needed?
+        'requests(>=0.13.3)',
     ],
     install_requires=[
-        'requests>=0.9.0',
+        'requests>=0.13.3',
     ],
     tests_require=['mock'],
     test_suite='pyelasticsearch.tests',


### PR DESCRIPTION
requests.compat.json was introduced in 0.13.3.
