### PR TITLE
Handle Decimal serialization

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -221,7 +221,7 @@ class ElasticSearch(object):
 
     def _encode_json(self, body):
         """Return body encoded as JSON."""
-        return json.dumps(body, cls=self.json_encoder)
+        return json.dumps(body, cls=self.json_encoder, use_decimal=True)
 
     def _decode_response(self, response):
         """Return a native-Python representation of a response's JSON blob."""


### PR DESCRIPTION
Had in issue where if my document had a Decimal I would get "ValueError: Circular reference detected". While the error is the same it is a different issue then what was reporting in #28
