### PR TITLE
Allow the search API to set from and size parameters as es_kwargs

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -415,7 +415,7 @@ class ElasticSearch(object):
             body,
             query_params=query_params)
 
-    @es_kwargs('routing')
+    @es_kwargs('routing', 'size', 'from')
     def search(self, query, **kwargs):
         """
         Execute a search query against one or more indices and get back search

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -245,6 +245,10 @@ class SearchTestCase(ElasticSearchTestCase):
         result = self.conn.count('name:joe', index='test-index')
         self.assertResultContains(result, {'count': 1})
 
+    def testSearchStringPaginated(self):
+        result = self.conn.search('*:*', index='test-index', es_from=1, es_size=1)
+        self.assertResultContains(result, {'hits': {'hits': [{'_score': 1, '_type': 'test-type', '_id': '2', '_source': {'name': 'Bill Baloney'}, '_index': 'test-index'}], 'total': 2, 'max_score': 1}})
+
     def testSearchByField(self):
         result = self.conn.search('name:joe', index='test-index')
         self.assertResultContains(result, {'hits': {'hits': [{'_score': 0.19178301, '_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'}], 'total': 1, 'max_score': 0.19178301}})


### PR DESCRIPTION
so that one can use `conn.search('query', es_from=10, es_size=20)` and have pagination without having to use the query DSL
