### PR TITLE
a new method on the client for using ES's Multi Get API

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,7 +36,7 @@ elasticsearch.
 
     .. automethod:: get(index, doc_type, id[, other kwargs listed below])
 
-    .. automethod:: mget(index, doc_type, ids[, other kwargs listed below])
+    .. automethod:: multi_get(index, doc_type, ids[, other kwargs listed below])
 
     .. automethod:: search(query, index, doc_type[, other kwargs listed below])
 

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -402,7 +402,7 @@ class ElasticSearch(object):
                                   query_params=query_params)
 
     @es_kwargs('routing')
-    def mget(self, index, doc_type, ids, query_params=None):
+    def multi_get(self, index, doc_type, ids, query_params=None):
         """
         Get multiple typed JSON documents from an index by their IDs.
 

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -242,7 +242,7 @@ class SearchTestCase(ElasticSearchTestCase):
         self.assertResultContains(result, {'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'})
 
     def testMultiGetByID(self):
-        result = self.conn.mget('test-index', 'test-type', [1, 2])
+        result = self.conn.multi_get('test-index', 'test-type', [1, 2])
         self.assertTrue('docs' in result)
         self.assertResultContains(result['docs'][0], {'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index', 'exists': True})
         self.assertResultContains(result['docs'][1], {'_type': 'test-type', '_id': '2', '_source': {'name': 'Bill Baloney'}, '_index': 'test-index', 'exists': True})


### PR DESCRIPTION
see http://www.elasticsearch.org/guide/reference/api/multi-get.html
