### PR TITLE
avoiding a NoneType error in method.__doc__

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -33,7 +33,7 @@ def _add_es_kwarg_docs(params, method):
     """
     doc = method.__doc__
     for p in params:
-        if ('\n        :arg %s: ' % p) not in doc:
+        if doc and ('\n        :arg %s: ' % p) not in doc:
             # Find the last documented arg so we can put our generated docs
             # after it. No need to explicitly compile this; the regex cache
             # should serve.


### PR DESCRIPTION
This error just happen in our testing server, not in our local machine. The only difference is that the server uses nginx/uwsgi.

It seems method.**doc** could come empty. and I get this error:

Exception Value: argument of type 'NoneType' is not iterable
Exception Location: .../local/lib/python2.7/site-packages/pyelasticsearch/client.py in _add_es_kwarg_docs, line 36
