### PR TITLE
Fix search docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,7 +36,7 @@ elasticsearch.
 
     .. automethod:: get(index, doc_type, id[, other kwargs listed below])
 
-    .. automethod:: search(query, index, doc_type[, other kwargs listed below])
+    .. automethod:: search(query[, other kwargs listed below])
 
     .. automethod:: count(query, index, doc_type[, other kwargs listed below])
 


### PR DESCRIPTION
It takes `index` and `doc_types` as kwargs--not regular args. So this
fixes the docs accordingly.

r?
