### PR TITLE
Make _send_request "public"

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -148,12 +148,12 @@ class ElasticSearch(object):
         raise TypeError("_to_query() doesn't know how to represent %r in an ES"
                         " query string." % obj)
 
-    def _send_request(self,
-                      method,
-                      path_components,
-                      body='',
-                      query_params=None,
-                      encode_body=True):
+    def send_request(self,
+                     method,
+                     path_components,
+                     body='',
+                     query_params=None,
+                     encode_body=True):
         """
         Send an HTTP request to ES, and return the JSON-decoded response.
 
@@ -287,7 +287,7 @@ class ElasticSearch(object):
         if force_insert:
             query_params['op_type'] = 'create'
 
-        return self._send_request('POST' if id is None else 'PUT',
+        return self.send_request('POST' if id is None else 'PUT',
                                   [index, doc_type, id],
                                   doc,
                                   query_params)
@@ -326,7 +326,7 @@ class ElasticSearch(object):
         # Need the trailing newline.
         body = '\n'.join(body_bits) + '\n'
         query_params['op_type'] = 'create'  # TODO: Why?
-        return self._send_request('POST',
+        return self.send_request('POST',
                                   [index, '_bulk'],
                                   body,
                                   encode_body=False,
@@ -347,7 +347,7 @@ class ElasticSearch(object):
             http://www.elasticsearch.org/guide/reference/api/delete.html
         """
         # TODO: Raise ValueError if id boils down to a 0-length string.
-        return self._send_request('DELETE', [index, doc_type, id],
+        return self.send_request('DELETE', [index, doc_type, id],
                                   query_params=query_params)
 
     @es_kwargs('routing', 'parent', 'replication', 'consistency', 'refresh')
@@ -365,7 +365,7 @@ class ElasticSearch(object):
         .. _`ES's delete API`:
             http://www.elasticsearch.org/guide/reference/api/delete.html
         """
-        return self._send_request('DELETE', [index, doc_type],
+        return self.send_request('DELETE', [index, doc_type],
                                   query_params=query_params)
 
     @es_kwargs('q', 'df', 'analyzer', 'default_operator', 'source' 'routing',
@@ -383,7 +383,7 @@ class ElasticSearch(object):
         .. _`ES's delete-by-query API`:
             http://www.elasticsearch.org/guide/reference/api/delete-by-query.html
         """
-        return self._send_request('DELETE', [index, doc_type, '_query'], query,
+        return self.send_request('DELETE', [index, doc_type, '_query'], query,
                                   query_params=query_params)
 
     @es_kwargs('realtime', 'fields', 'routing', 'preference', 'refresh')
@@ -400,7 +400,7 @@ class ElasticSearch(object):
         .. _`ES's get API`:
             http://www.elasticsearch.org/guide/reference/api/get.html
         """
-        return self._send_request('GET', [index, doc_type, id],
+        return self.send_request('GET', [index, doc_type, id],
                                   query_params=query_params)
 
     def _search_or_count(self, kind, query, index=None, doc_type=None,
@@ -411,7 +411,7 @@ class ElasticSearch(object):
         else:
             body = query
 
-        return self._send_request(
+        return self.send_request(
             'GET',
             [self._concat(index), self._concat(doc_type), kind],
             body,
@@ -471,7 +471,7 @@ class ElasticSearch(object):
         """
         # TODO: Think about turning index=None into _all if doc_type is non-
         # None, per the ES doc page.
-        return self._send_request(
+        return self.send_request(
             'GET',
             [self._concat(index), self._concat(doc_type), '_mapping'],
             query_params=query_params)
@@ -496,7 +496,7 @@ class ElasticSearch(object):
         # don't need to expose the "_all" magic string. We haven't done it yet
         # since this routine is not dangerous: ES makes you explicily pass
         # "_all" to update all mappings.
-        return self._send_request(
+        return self.send_request(
             'PUT',
             [self._concat(index), doc_type, '_mapping'],
             mapping,
@@ -527,7 +527,7 @@ class ElasticSearch(object):
             http://www.elasticsearch.org/guide/reference/api/more-like-this.html
         """
         query_params['fields'] = self._concat(fields)  # TODO: ES docs say "mlt_fields".
-        return self._send_request('GET',
+        return self.send_request('GET',
                                   [index, doc_type, id, '_mlt'],
                                   body=body,
                                   query_params=query_params)
@@ -546,7 +546,7 @@ class ElasticSearch(object):
         .. _`ES's index-status API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-status.html
         """
-        return self._send_request('GET', [self._concat(index), '_status'],
+        return self.send_request('GET', [self._concat(index), '_status'],
                                   query_params=query_params)
 
     @es_kwargs()
@@ -562,7 +562,7 @@ class ElasticSearch(object):
         .. _`ES's create-index API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index.html
         """
-        return self._send_request('PUT', [index], body=settings,
+        return self.send_request('PUT', [index], body=settings,
                                   query_params=query_params)
 
     @es_kwargs()
@@ -580,7 +580,7 @@ class ElasticSearch(object):
         if not index:
             raise ValueError('No indexes specified. To delete all indexes, use'
                              ' delete_all_indexes().')
-        return self._send_request('DELETE', [self._concat(index)],
+        return self.send_request('DELETE', [self._concat(index)],
                                   query_params=query_params)
 
     def delete_all_indexes(self, **kwargs):
@@ -599,7 +599,7 @@ class ElasticSearch(object):
         .. _`ES's close-index API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-open-close.html
         """
-        return self._send_request('POST', [index, '_close'],
+        return self.send_request('POST', [index, '_close'],
                                   query_params=query_params)
 
     @es_kwargs()
@@ -614,7 +614,7 @@ class ElasticSearch(object):
         .. _`ES's open-index API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-open-close.html
         """
-        return self._send_request('POST', [index, '_open'],
+        return self.send_request('POST', [index, '_open'],
                                   query_params=query_params)
 
     @es_kwargs()
@@ -635,7 +635,7 @@ class ElasticSearch(object):
                              ' update_all_settings().')
         # If we implement the "update cluster settings" API, call that
         # update_cluster_settings().
-        return self._send_request('PUT',
+        return self.send_request('PUT',
                                   [self._concat(index), '_settings'],
                                   body=settings,
                                   query_params=query_params)
@@ -652,7 +652,7 @@ class ElasticSearch(object):
         .. _`ES's update-settings API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings.html
         """
-        return self._send_request('PUT', ['_settings'], body=settings,
+        return self.send_request('PUT', ['_settings'], body=settings,
                                   query_params=query_params)
 
     @es_kwargs('refresh')
@@ -667,7 +667,7 @@ class ElasticSearch(object):
         .. _`ES's flush API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-flush.html
         """
-        return self._send_request('POST',
+        return self.send_request('POST',
                                   [self._concat(index), '_flush'],
                                   query_params=query_params)
 
@@ -683,7 +683,7 @@ class ElasticSearch(object):
         .. _`ES's refresh API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-refresh.html
         """
-        return self._send_request('POST', [self._concat(index), '_refresh'],
+        return self.send_request('POST', [self._concat(index), '_refresh'],
                                   query_params=query_params)
 
     @es_kwargs()
@@ -698,7 +698,7 @@ class ElasticSearch(object):
         .. _`ES's gateway-snapshot API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-gateway-snapshot.html
         """
-        return self._send_request(
+        return self.send_request(
             'POST',
             [self._concat(index), '_gateway', 'snapshot'],
             query_params=query_params)
@@ -716,7 +716,7 @@ class ElasticSearch(object):
         .. _`ES's optimize API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize.html
         """
-        return self._send_request('POST',
+        return self.send_request('POST',
                                   [self._concat(index), '_optimize'],
                                   query_params=query_params)
 
@@ -733,7 +733,7 @@ class ElasticSearch(object):
         .. _`ES's cluster-health API`:
             http://www.elasticsearch.org/guide/reference/api/admin-cluster-health.html
         """
-        return self._send_request(
+        return self.send_request(
             'GET',
             ['_cluster', 'health', self._concat(index)],
             query_params=query_params)

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -64,29 +64,29 @@ class IndexingTestCase(ElasticSearchTestCase):
 
     def testUpdateSettings(self):
         """Make sure ``update_settings()`` sends the expected request."""
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.update_settings(['test-index', 'toast-index'],
                                       {'index': {'number_of_replicas': 2}})
-        _send_request.assert_called_once_with(
+        send_request.assert_called_once_with(
             'PUT',
             ['test-index,toast-index', '_settings'],
             body={'index': {'number_of_replicas': 2}},
             query_params={})
 
     def testHealth(self):
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.health(['test-index', 'toast-index'],
                              wait_for_status='yellow',
                              wait_for_nodes='>=1')
-        _send_request.assert_called_once_with(
+        send_request.assert_called_once_with(
             'GET',
             ['_cluster', 'health', 'test-index,toast-index'],
             query_params={'wait_for_status': 'yellow',
                           'wait_for_nodes': '>=1'})
 
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.health()
-        _send_request.assert_called_once_with(
+        send_request.assert_called_once_with(
             'GET', ['_cluster', 'health', ''], query_params={})
 
     def testDeleteByID(self):
@@ -309,9 +309,9 @@ class DangerousOperationTests(ElasticSearchTestCase):
     """
     def test_delete_all(self):
         """Make sure ``delete_all()`` sends the right request."""
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.delete_all('test-index', 'tweet')
-        _send_request.assert_called_once_with(
+        send_request.assert_called_once_with(
             'DELETE',
             ['test-index', 'tweet'],
             query_params={})
@@ -324,9 +324,9 @@ class DangerousOperationTests(ElasticSearchTestCase):
 
     def test_delete_all_indexes(self):
         """Make sure ``delete_all_indexes()`` sends the right request."""
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.delete_all_indexes()
-        _send_request.assert_called_once_with('DELETE', [''], query_params={})
+        send_request.assert_called_once_with('DELETE', [''], query_params={})
 
     def update_settings_no_args(self):
         """
@@ -337,9 +337,9 @@ class DangerousOperationTests(ElasticSearchTestCase):
 
     def update_all_settings(self):
         """Make sure ``update_all_settings()`` sends the right request."""
-        with patch.object(self.conn, '_send_request') as _send_request:
+        with patch.object(self.conn, 'send_request') as send_request:
             self.conn.update_all_settings({'joe': 'bob'})
-        _send_request.assert_called_once_with(
+        send_request.assert_called_once_with(
             'PUT', ['_settings'], body={'joe': 'bob'})
 
 


### PR DESCRIPTION
This is cosmetic, but it changes _send_request to send_request which
has the implication that it's "part of the API" now.

The use case for this is that I'm creating a CurlyElasticSearch class
that wraps the send_request method and logs the ES requests in a
"curl-ified" way making it really easy to debug problems by copy
and pasting the curl lines.

r?
