### PR TITLE
Change debug log to use curl syntax

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -196,8 +196,9 @@ class ElasticSearch(object):
             server_url, was_dead = self.servers.get()
             url = server_url + path
             self.logger.debug(
-                'making %s request to path: %s %s with body: %s',
-                method, url, path, kwargs.get('data', {}))
+                'request: curl -X%s \'%s\' -d \'%s\'' % (
+                    method, url, kwargs.get('data', {})))
+
             try:
                 # prefetch=True so the connection can be quickly returned to
                 # the pool. This is the default in requests >=0.3.16.


### PR DESCRIPTION
Tweaked the logging so that it uses curl syntax when logging the ES
request. This has the fancy advantage of letting you copy and paste
the curl line and execute it on its own to debug issues.

r?
