### PR TITLE
fix update api url and add tests

### DIFF
--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -215,7 +215,7 @@ class IndexingTestCase(ElasticSearchTestCase):
                              params={'count': 5},
                              lang='python')
         send_request.assert_called_once_with(
-            'POST', ['some_index', 'some_type', 3],
+            'POST', ['some_index', 'some_type', 3, '_update'],
             body={'script': SCRIPT,
                   'params': {'count': 5},
                   'lang': 'python'},


### PR DESCRIPTION
`ElasticSearch.update()` calls use the wrong url (it should end in '_update', see http://www.elasticsearch.org/guide/reference/api/update.html).

This patch breaks the existing update test, however since it's using the wrong url I'm not sure why it's passing (I'm not entirely sure what it's trying to test). So I replaced the test with the calls on the es update api page.

This change also changes the params for `update()`. I couldn't work out how to specify the script `lang` parameter to the es update api so I've left it out.
