### PR TITLE
Fix bulk indexing endpoint

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -336,7 +336,7 @@ class ElasticSearch(object):
         body = '\n'.join(body_bits) + '\n'
         query_params['op_type'] = 'create'  # TODO: Why?
         return self.send_request('POST',
-                                  [index, '_bulk'],
+                                  ['_bulk'],
                                   body,
                                   encode_body=False,
                                   query_params=query_params)


### PR DESCRIPTION
The /{index}/_bulk endpoint wasn't added until ES 0.18.0:

https://github.com/elasticsearch/elasticsearch/issues/1375

This fixes pyelasticsearch so that it uses /_bulk as the endpoint
and thus works with versions of ES prior to 0.18.0.

This fixes issue #59.
