### PR TITLE
Add cluster/_state API

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -76,6 +76,8 @@ so it'll be hard to miss.
 
     .. automethod:: health(index=None[, other kwargs listed below])
 
+    .. automethod:: cluster_state([other kwargs listed below])
+
     .. automethod:: send_request
 
 

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -776,6 +776,24 @@ class ElasticSearch(object):
             ['_cluster', 'health', self._concat(index)],
             query_params=query_params)
 
+    @es_kwargs('filter_nodes', 'filter_routing_table', 'filter_metadata',
+               'filter_blocks', 'filter_indices')
+    def cluster_state(self, query_params=None):
+        """
+        The cluster state API allows to get comprehensive state
+        information of the whole cluster.
+
+        :arg query_params: A map of querystring param names to values or
+            ``None``
+
+        See `ES's cluster-state API`_ for more detail.
+
+        .. _`ES's cluster-state API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-cluster-state.html
+        """
+        return self.send_request(
+            'GET', ['_cluster', 'state'], query_params=query_params)
+
     def from_python(self, value):
         """
         Convert Python values to a form suitable for ElasticSearch's JSON.

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -94,6 +94,11 @@ class IndexingTestCase(ElasticSearchTestCase):
         send_request.assert_called_once_with(
             'GET', ['_cluster', 'health', ''], query_params={})
 
+    def testClusterState(self):
+        result = self.conn.cluster_state(filter_routing_table=True)
+        self.assertTrue('nodes' in result)
+        self.assertFalse('routing_table' in result)
+
     def testDeleteByID(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
         self.conn.refresh(['test-index'])


### PR DESCRIPTION
This adds a method for ES' `cluster/_state` API (http://www.elasticsearch.org/guide/reference/api/admin-cluster-state.html).
