### PR TITLE
add index template API (/_template)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -66,6 +66,14 @@ so it'll be hard to miss.
 
     .. automethod:: update_all_settings(settings)
 
+    .. automethod:: create_template(name, settings)
+
+    .. automethod:: get_template(name)
+
+    .. automethod:: delete_template(name)
+
+    .. automethod:: list_templates
+
     .. automethod:: flush(index=None[, other kwargs listed below])
 
     .. automethod:: refresh(index=None)

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -693,6 +693,65 @@ class ElasticSearch(object):
         return self.send_request('PUT', ['_settings'], body=settings,
                                  query_params=query_params)
 
+    @es_kwargs()
+    def create_template(self, name, settings, query_params=None):
+        """
+        Create an index template.
+
+        :arg name: The name of the template.
+        :arg settings: A dictionary of settings.
+
+        See `ES's index-template API`_ for more detail.
+
+        .. _`ES's index-template API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html
+        """
+        return self.send_request('PUT', ['_template', name], settings,
+            query_params=query_params)
+
+    @es_kwargs()
+    def delete_template(self, name, query_params=None):
+        """
+        Delete an index template.
+
+        :arg name: The name of the template.
+
+        See `ES's index-template API`_ for more detail.
+
+        .. _`ES's index-template API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html
+        """
+        return self.send_request('DELETE', ['_template', name],
+            query_params=query_params)
+
+    @es_kwargs()
+    def get_template(self, name, query_params=None):
+        """
+        Get the settings of an index template.
+
+        :arg name: The name of the template.
+
+        See `ES's index-template API`_ for more detail.
+
+        .. _`ES's index-template API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html
+        """
+        return self.send_request('GET', ['_template', name],
+            query_params=query_params)
+
+    def list_templates(self):
+        """
+        Get a dictionary with all index template settings.
+
+        See `ES's index-template API`_ for more detail.
+
+        .. _`ES's index-template API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html
+        """
+        res = self.cluster_state(filter_routing_table=True,
+            filter_nodes=True, filter_blocks=True)
+        return res['metadata']['templates']
+
     @es_kwargs('refresh')
     def flush(self, index=None, query_params=None):
         """

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -27,7 +27,7 @@ class ElasticSearchTestCase(unittest.TestCase):
     def tearDown(self):
         try:
             self.conn.delete_index('test-index')
-        except Exception:
+        except ElasticHttpNotFoundError:
             pass
 
     def assertResultContains(self, result, expected):
@@ -359,13 +359,13 @@ class TemplateTests(unittest.TestCase):
     def tearDown(self):
         try:
             self.conn.delete_index('test-index-1')
-        except Exception:
+        except ElasticHttpNotFoundError:
             pass
         # clean up extra templates
         for t in self.added_templates:
             try:
                 self.conn.delete_template(t)
-            except Exception:
+            except ElasticHttpNotFoundError:
                 pass
 
     def test_create_template(self):


### PR DESCRIPTION
This adds methods for the _template API's (http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html).

In addition there's a `list_templates` API, based on the cluster/_state API as a convenience. This pull requests depends on https://github.com/rhec/pyelasticsearch/pull/63 for the cluster_state method.