### PR TITLE
Add index warmer API

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -74,11 +74,11 @@ so it'll be hard to miss.
 
     .. automethod:: optimize(index=None[, other kwargs listed below])
 
-    .. automethod:: create_warmer(index, doc_type, name, warmer)
+    .. automethod:: create_warmer(index, doc_type, name, warmer[, other kwargs listed below])
 
-    .. automethod:: delete_warmer(index, doc_type=None, name=None)
+    .. automethod:: delete_warmer(index, doc_type=None, name=None[, other kwargs listed below])
 
-    .. automethod:: get_warmer(index, doc_type=None, name=None)
+    .. automethod:: get_warmer(index, doc_type=None, name=None[, other kwargs listed below])
 
     .. automethod:: health(index=None[, other kwargs listed below])
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -74,6 +74,12 @@ so it'll be hard to miss.
 
     .. automethod:: optimize(index=None[, other kwargs listed below])
 
+    .. automethod:: create_warmer(index, doc_type, name, warmer)
+
+    .. automethod:: delete_warmer(index, doc_type=None, name=None)
+
+    .. automethod:: get_warmer(index, doc_type=None, name=None)
+
     .. automethod:: health(index=None[, other kwargs listed below])
 
     .. automethod:: send_request

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -758,6 +758,68 @@ class ElasticSearch(object):
                                  [self._concat(index), '_optimize'],
                                  query_params=query_params)
 
+    @es_kwargs()
+    def create_warmer(self, index, doc_type, name, warmer, query_params=None):
+        """
+        Create an index warmer.
+
+        :arg index: An index or iterable of indexes
+        :arg doc_type: The document type to set the warmer for, can be
+            None to let the warmer apply to all types.
+        :arg name: The name of the warmer
+        :arg warmer: The warmer definition
+
+        See `ES's index-warmer API`_ for more detail.
+
+        .. _`ES's index-warmer API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers.html
+        """
+        return self.send_request(
+            'PUT',
+            [self._concat(index), self._concat(doc_type), '_warmer', name],
+            warmer,
+            query_params=query_params)
+
+    @es_kwargs()
+    def delete_warmer(self, index, doc_type=None, name=None, query_params=None):
+        """
+        Delete one or many index warmers.
+
+        :arg index: An index or iterable of indexes
+        :arg doc_type: The document type to set the warmer for
+        :arg name: The name of the warmer
+
+        See `ES's index-warmer API`_ for more detail.
+
+        .. _`ES's index-warmer API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers.html
+        """
+        return self.send_request(
+            'DELETE',
+            [self._concat(index), self._concat(doc_type),
+             '_warmer', self._concat(name)],
+            query_params=query_params)
+
+    @es_kwargs()
+    def get_warmer(self, index, doc_type=None, name=None, query_params=None):
+        """
+        Get one or many index warmer settings.
+
+        :arg index: An index or iterable of indexes
+        :arg doc_type: The document type the warmer was set for
+        :arg name: The name of the warmer
+
+        See `ES's index-warmer API`_ for more detail.
+
+        .. _`ES's index-warmer API`:
+            http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers.html
+        """
+        return self.send_request(
+            'GET',
+            [self._concat(index), self._concat(doc_type),
+             '_warmer', self._concat(name)],
+            query_params=query_params)
+
     @es_kwargs('level', 'wait_for_status', 'wait_for_relocating_shards',
                'wait_for_nodes', 'timeout')
     def health(self, index=None, query_params=None):

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -309,6 +309,69 @@ class SearchTestCase(ElasticSearchTestCase):
                 {u'hits': {u'hits': [{u'_score': 0.30685282, u'_type': u'test-type', u'_id': u'4', u'_source': {u'sport': u'football', u'name': u'Cam'}, u'_index': u'test-index'}], u'total': 1, u'max_score': 0.30685282}})
 
 
+class WarmerTests(unittest.TestCase):
+    """
+    Tests for the index warmer API, added in ES 0.20.
+    """
+
+    def setUp(self):
+        self.conn = ElasticSearch('http://localhost:9200/')
+        self.conn.create_index('test-warm', settings={
+            'number_of_replicas': 0, 'number_of_shards': 1
+        })
+        self.conn.index('test-warm', 'test-type', {'foo': 1})
+
+    def tearDown(self):
+        try:
+            self.conn.delete_warmer('test-warm')
+        except Exception:
+            pass
+        try:
+            self.conn.delete_index('test-warm')
+        except Exception:
+            pass
+
+    def _make_one(self, name, doc_type='test-type'):
+        result = self.conn.create_warmer('test-warm', doc_type, name,
+            warmer={'query': {'match_all': {}}})
+        self.conn.refresh('test-warm')
+        return result
+
+    def test_create_warmer(self):
+        result = self._make_one('warmer1', doc_type=None)
+        self.assertTrue(result['acknowledged'])
+
+    def test_create_type_warmer(self):
+        result = self._make_one('warmer1')
+        self.assertTrue(result['acknowledged'])
+
+    def test_delete_warmer(self):
+        self._make_one('warmer1')
+        result = self.conn.delete_warmer('test-warm', 'test-type', 'warmer1')
+        self.assertTrue(result['acknowledged'])
+
+    def test_delete_all_warmers(self):
+        self._make_one('warmer1')
+        self._make_one('warmer2')
+        result = self.conn.delete_warmer('test-warm')
+        self.assertTrue(result['acknowledged'])
+
+    def test_get_warmer(self):
+        self._make_one('warmer1')
+        result = self.conn.get_warmer('test-warm', 'test-type', 'warmer1')
+        self.assertTrue('test-warm' in result)
+        self.assertEqual(result['test-warm']['warmers']['warmer1']['source'],
+            {'query': {'match_all': {}}})
+
+    def test_get_warmers(self):
+        self._make_one('warmer1')
+        self._make_one('warmer2')
+        result = self.conn.get_warmer('test-warm')
+        self.assertTrue('test-warm' in result)
+        self.assertEqual(set(result['test-warm']['warmers'].keys()),
+            set(['warmer1', 'warmer2']))
+
+
 class DangerousOperationTests(ElasticSearchTestCase):
     """
     Tests that confirm callers can't do dangerous operations by accident and


### PR DESCRIPTION
Add methods for index warmer API (http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers.html).

These are new API's in ES 0.20.x. So the tests work and run against ES 0.20. Not sure if I should try to discover the ES version in the tests and skip these, if ES < 0.20 is detected.