### PR TITLE
Speed-up bulk indexing calls

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -347,7 +347,6 @@ class ElasticSearch(object):
 
         # Need the trailing newline.
         body = '\n'.join(body_bits) + '\n'
-        query_params['op_type'] = 'create'  # TODO: Why?
         return self.send_request('POST',
                                  [index, doc_type, '_bulk'],
                                  body,


### PR DESCRIPTION
See commit messages for details - this makes the action lines shorter and avoids some per document JSON encoding, if no explicit ids are provided.
