### PR TITLE
Make tests run much faster.

### DIFF
--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -210,7 +210,7 @@ class IndexingTestCase(ElasticSearchTestCase):
 
     def testErrorHandling(self):
         # Wrong port.
-        conn = ElasticSearch('http://example.com:1009200/')
+        conn = ElasticSearch('http://localhost:1009200/')
         self.assertRaises(ConnectionError, conn.count, '*:*')
 
         # Test invalid JSON.


### PR DESCRIPTION
This means that if, by some chance, you are running ES on port 1009200,
this test will fail. I am fine with that tiny tiny risk
