### PR TITLE
Allow documents with 0 ID

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -366,7 +366,9 @@ class ElasticSearch(object):
         .. _`ES's delete API`:
             http://www.elasticsearch.org/guide/reference/api/delete.html
         """
-        # TODO: Raise ValueError if id boils down to a 0-length string.
+        if id is None or id == '':
+            raise ValueError('No ID specified. To delete all documents in '
+                'an index, use delete_all().')
         return self.send_request('DELETE', [index, doc_type, id],
                                  query_params=query_params)
 

--- a/pyelasticsearch/tests.py
+++ b/pyelasticsearch/tests.py
@@ -115,6 +115,20 @@ class IndexingTestCase(ElasticSearchTestCase):
         result = self.conn.delete('test-index', 'test-type', 1)
         self.assertResultContains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
 
+    def testDeleteBy0ID(self):
+        self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=0)
+        self.conn.refresh(['test-index'])
+        result = self.conn.delete('test-index', 'test-type', 0)
+        self.assertResultContains(result, {'_type': 'test-type', '_id': '0', 'ok': True, '_index': 'test-index'})
+
+    def testDeleteByIdWithoutId(self):
+        self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
+        self.conn.refresh(['test-index'])
+        self.assertRaises(
+            ValueError, self.conn.delete, 'test-index', 'test-type', '')
+        self.assertRaises(
+            ValueError, self.conn.delete, 'test-index', 'test-type', None)
+
     def testDeleteByDocType(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
         self.conn.refresh(["test-index"])


### PR DESCRIPTION
Allow a document to be indexed with an ID of 0. Also, raise a `ValueError` if `delete` is called without an ID.

Will break code that uses `delete('index', 'doc_type', '')` in lieu of `delete_all('index', 'doc_type')`.
