### PR TITLE
make py.test find test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 *.egg
 .idea
 .*.swp
+__pycache__/

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,6 @@ envlist = py26, py27, py33, pypy
 
 [testenv]
 commands = python setup.py test
+
+[pytest]
+python_files = *_tests.py


### PR DESCRIPTION
pytest is able to run the nose tests, but it needs a bit of help to
find them. since it reads the tox.ini file, we just need to add a glob
pattern there.

py.test will also create **pycache** directories. add them to
.gitignore.
