### PR TITLE
Implement multi-search API. Add related test case.

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -588,6 +588,51 @@ class ElasticSearch(object):
         """
         return self._search_or_count('_search', query, **kwargs)
 
+    @es_kwargs('search_type', 'preference', 'routing')
+    def multi_search(self, queries, indexes=None, query_params=None):
+        """
+        Execute a multi search query.
+
+        :arg queries: A list of dictionaries that will convert to ES's query DSL or a
+            string that will serve as a textual query to be passed as the ``q``
+            query string parameter
+        :arg indexes: An iterable, each element of which must be an index name
+
+        See `ES's Multi Search API`_ for more details.
+
+        .. _`ES's Multi Search API`:
+            http://www.elasticsearch.org/guide/reference/api/multi-search.html
+        """
+
+        body_bits = []
+
+        if not queries:
+            raise ValueError('No query is given.')
+
+        if not isinstance(queries, list):
+            raise TypeError('queries parameter must be a list.')
+
+        if indexes is None or (len(indexes) != len(queries)):
+            self.logger.warning('Either indexes is None or the number of given \
+                                indexes doesn\'t match the number of given \
+                                queries. Indexes will be empty.')
+            indexes = [{} for _ in queries]
+
+        for i, query in enumerate(queries):
+            index = {'index': indexes[i]}
+
+            body_bits.append(self._encode_json(index))
+            body_bits.append(self._encode_json(query))
+
+        # Need the trailing newline.
+        body = '\n'.join(body_bits) + '\n'
+
+        return self.send_request('GET',
+                                ['_msearch'],
+                                body,
+                                encode_body=False,
+                                query_params=query_params)
+
     @es_kwargs('df', 'analyzer', 'default_operator', 'source', 'routing')
     def count(self, query, **kwargs):
         """

--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -357,6 +357,19 @@ class SearchTestCase(ElasticSearchTestCase):
         result = self.conn.multi_get([{'_type': 'test-type', '_id': 1, 'fields': ['name'], '_index': 'test-index'}])
         self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', 'fields': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]})
 
+    def test_multi_search(self):
+        self.conn.index('another-test-index', 'test-type', {'name': 'Jane Tester'}, id=3)
+        self.conn.refresh(['another-test-index'])
+
+        indexes = ['test-index', 'another-test-index']
+
+        queries = [
+            {'query' : {'match_all' : {}}, 'from' : 0, 'size' : 1},
+            {'query' : {'match_all' : {}}, 'from' : 0, 'size' : 1}
+        ]
+        result = self.conn.multi_search(queries, indexes)
+        ok_(result.get('responses').__len__(), 2)
+
     def test_get_count_by_search(self):
         result = self.conn.count('name:joe', index='test-index')
         self.assert_result_contains(result, {'count': 1})


### PR DESCRIPTION
This patch enables multi-search API of ElasticSearch. Related test case is in the patch too.
