### PR TITLE
Added support for percolator queries in bulk_index

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -344,7 +344,7 @@ class ElasticSearch(object):
 
     @es_kwargs('consistency', 'refresh')
     def bulk_index(self, index, doc_type, docs, id_field='id',
-                   parent_field='_parent', query_params=None):
+                   parent_field='_parent', percolate = None, query_params=None):
         """
         Index a list of documents as efficiently as possible.
 
@@ -355,6 +355,8 @@ class ElasticSearch(object):
         :arg id_field: The field of each document that holds its ID
         :arg parent_field: The field of each document that holds its parent ID,
             if any. Removed from document before indexing. 
+        :arg percolate: The name of the registered percolator query to execute
+            against on document indexing (can be "*")
 
         See `ES's bulk API`_ for more detail.
 
@@ -374,6 +376,9 @@ class ElasticSearch(object):
 
             if doc.get(parent_field) is not None:
                 action['index']['_parent'] = doc.pop(parent_field)
+
+            if percolate is not None:
+                action['index']['_percolate'] = percolate
 
             body_bits.append(self._encode_json(action))
             body_bits.append(self._encode_json(doc))


### PR DESCRIPTION
Elasticsearch supports percolator queries on bulk index and returns the matching queries in the return value.  This patch adds a parameter to bulk_index as described in the percolate section in http://www.elasticsearch.org/guide/reference/api/index_/
