### PR TITLE
Cleanup _percolate index so it isn't left behind from tests.

### DIFF
--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -326,8 +326,10 @@ class IndexingTestCase(ElasticSearchTestCase):
 
         # Percolate a document that shouldn't match any queries
         document = { 'doc': {'name': 'blah'} }
-        result = self.conn.percolate('test-index','test-type', document)
+        result = self.conn.percolate('test-index', 'test-type', document)
         self.assert_result_contains(result, {'matches': [], 'ok': True})
+
+        self.conn.delete_index('_percolator')
 
 
 class SearchTestCase(ElasticSearchTestCase):


### PR DESCRIPTION
I noticed this when running tests locally. If there's a better way to clean this up let me know. Thanks.
