### PR TITLE
Allow bulk_index to insert different type of documents

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -356,7 +356,9 @@ class ElasticSearch(object):
             representing documents to index
         :arg id_field: The field of each document that holds its ID
         :arg parent_field: The field of each document that holds its parent ID,
-            if any. Removed from document before indexing. 
+            if any. Removed from document before indexing.
+        :arg type_field: The field of each document that holds its doc type.
+            Overrides doc_type argument, if field is present in document
 
         See `ES's bulk API`_ for more detail.
 

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -345,7 +345,8 @@ class ElasticSearch(object):
 
     @es_kwargs('consistency', 'refresh')
     def bulk_index(self, index, doc_type, docs, id_field='id',
-                   parent_field='_parent', query_params=None):
+                   parent_field='_parent', query_params=None,
+                   type_field=None):
         """
         Index a list of documents as efficiently as possible.
 
@@ -368,6 +369,7 @@ class ElasticSearch(object):
             raise ValueError('No documents provided for bulk indexing!')
 
         for doc in docs:
+            doc_type = doc.get(type_field) or doc_type
             action = {'index': {'_index': index, '_type': doc_type}}
 
             if doc.get(id_field) is not None:

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -369,7 +369,7 @@ class ElasticSearch(object):
             raise ValueError('No documents provided for bulk indexing!')
 
         for doc in docs:
-            doc_type = doc.get(type_field) or doc_type
+            doc_type = doc.pop(type_field, None) or doc_type
             action = {'index': {'_index': index, '_type': doc_type}}
 
             if doc.get(id_field) is not None:

--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -220,13 +220,16 @@ class IndexingTestCase(ElasticSearchTestCase):
 
         docs = [
             {'name': 'Joe Tester'},
-            {'name': 'Bill Baloney', 'id': 303},
+            {'name': 'Bill Baloney', 'id': 303, '_type': 'another-type'},
         ]
-        result = self.conn.bulk_index('test-index', 'test-type', docs)
+        result = self.conn.bulk_index('test-index', 'test-type', docs,
+                                      type_field='_type')
         eq_(len(result['items']), 2)
         eq_(result['items'][0]['create']['ok'], True)
+        eq_(result['items'][0]['create']['_type'], 'test-type')
         eq_(result['items'][1]['index']['ok'], True)
         eq_(result['items'][1]['index']['_id'], '303')
+        eq_(result['items'][1]['index']['_type'], 'another-type')
         self.conn.refresh()
         eq_(self.conn.count('*:*',
                                          index=['test-index'])['count'], 2)


### PR DESCRIPTION
Since API allows it, there is no point of limiting bulk_index with
only one type of document. This is very useful feature when you are
cloning an index, and don't care about the exact types.