### PR TITLE
Missed quote in example

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -63,7 +63,7 @@ Ints, longs, and floats
     Converted to strings via ``str()``
 
 Lists and tuples
-    Joined with commas, e.g. ``['one-index', two-index']`` becomes
+    Joined with commas, e.g. ``['one-index', 'two-index']`` becomes
     ``one-index,two-index``
 
 Datetimes and dates


### PR DESCRIPTION
Just added  a missed quote in the documentation.
