### PR TITLE
Allow search_type to be passed through to query string via ElasticSearch...

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -566,7 +566,7 @@ class ElasticSearch(object):
             body,
             query_params=query_params)
 
-    @es_kwargs('routing', 'size')
+    @es_kwargs('routing', 'size', 'search_type')
     def search(self, query, **kwargs):
         """
         Execute a search query against one or more indices and get back search


### PR DESCRIPTION
Important for doing dfs_\* search types, among many others. I could not find another way to do this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pyelasticsearch/pyelasticsearch/142)

<!-- Reviewable:end -->
