### PR TITLE
Update client.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'simplejson(>=2.1.0)',
     ],
     install_requires=[
-        'requests>=1.0,<2.0',
+        'requests>=1.0,<3.0',
         'simplejson>=2.1.0',
         'six'
     ],


### PR DESCRIPTION
enable routing for bulk_index, needed for grandparent relations, for >2nd level children need routing param of the grandparent
