### PR TITLE
Remove simplejson dependency

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+v0.6.2 (not released yet)
+-------------------------
+
+* Remove dependency on simplejson.
+
+
 v0.6.1 (2013-11-01)
 -------------------
 

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -18,8 +18,8 @@ except ImportError:
     from urllib import urlencode, quote_plus
 
 import requests
-import simplejson as json  # for use_decimal
-from simplejson import JSONDecodeError
+import json
+from json import JSONDecodeError
 
 from pyelasticsearch.downtime import DowntimePronePool
 from pyelasticsearch.exceptions import (Timeout, ConnectionError,

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,9 @@ setup(
     requires=[  # Needed?
         'six',
         'requests(>=1.0,<3.0)',
-        'simplejson(>=2.1.0)',
     ],
     install_requires=[
         'requests>=1.0,<3.0',
-        'simplejson>=2.1.0',
         'six'
     ],
     tests_require=['mock', 'nose>=1.2.1'],


### PR DESCRIPTION
It seems unneeded now, since the only supported Python versions ship `json` in the stdlib.
