### PR TITLE
Fix delete query error in elasticsearch

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -450,7 +450,7 @@ class ElasticSearch(object):
             query_params['q'] = query
             body = ''
         else:
-            body = query
+            body = {"query": query}
         return self.send_request(
             'DELETE',
             [self._concat(index), self._concat(doc_type), '_query'],


### PR DESCRIPTION
Change elasticsearch API to query delete in last versions.

Old format:
{ 
   "query_string" : { 
        "query" : "some_query"     
   } 
} 

New format(after version 1.2.0 or early):
{ 
   "query" : { //added 
    "query_string" : { 
         "query" : "some_query"     
    } 
    } 
}