### PR TITLE
107 fix tests

### DIFF
--- a/pyelasticsearch/tests/__init__.py
+++ b/pyelasticsearch/tests/__init__.py
@@ -4,6 +4,7 @@ Unit tests for pyelasticsearch
 These require an elasticsearch server running on the default port
 (localhost:9200).
 """
+from functools import total_ordering
 import unittest
 
 from nose.tools import eq_
@@ -25,3 +26,17 @@ class ElasticSearchTestCase(unittest.TestCase):
     def assert_result_contains(self, result, expected):
         for (key, value) in expected.items():
             eq_(value, result[key])
+
+
+@total_ordering
+class EqualAnything(object):
+    def __eq__(self, other):
+        return True
+
+    def __lt__(self, other):
+        return True
+
+
+# The WHATEVER singleton is equal to everything. Use this for ignoring
+# specific values which can fluctuate in results comparison tests.
+WHATEVER = EqualAnything()

--- a/pyelasticsearch/tests/__init__.py
+++ b/pyelasticsearch/tests/__init__.py
@@ -26,10 +26,12 @@ class ElasticSearchTestCase(unittest.TestCase):
     def assert_result_contains(self, result, expected):
         for (key, value) in expected.items():
             eq_(value, result[key])
+        return True
 
 
 @total_ordering
 class EqualAnything(object):
+    """Class for comparing favorably with everything"""
     def __eq__(self, other):
         return True
 
@@ -40,3 +42,24 @@ class EqualAnything(object):
 # The WHATEVER singleton is equal to everything. Use this for ignoring
 # specific values which can fluctuate in results comparison tests.
 WHATEVER = EqualAnything()
+
+
+def eq_one_of(*tests):
+    """Runs an iterable of test functions until one returns True
+
+    Runs through an iterable of test functions executing each
+    individually. If the function raises an error, then the error is
+    ignored.
+
+    If none of the test functions return True, then this raises an
+    AssertionError.
+
+    """
+    for test_fun in tests:
+        try:
+            if test_fun():
+                return True
+        except Exception:
+            pass
+    else:
+        raise AssertionError('None of %r is true' % (tests,))

--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -9,7 +9,7 @@ import six
 
 # Test that __all__ is sufficient:
 from pyelasticsearch import *
-from pyelasticsearch.tests import ElasticSearchTestCase, WHATEVER
+from pyelasticsearch.tests import ElasticSearchTestCase, WHATEVER, eq_one_of
 
 
 class IndexingTestCase(ElasticSearchTestCase):
@@ -22,18 +22,18 @@ class IndexingTestCase(ElasticSearchTestCase):
 
     def test_indexing_with_id(self):
         result = self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': '1', '_index': 'test-index'})
 
     def test_indexing_with_0_id(self):
         result = self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=0)
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': '0', 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': '0', '_index': 'test-index'})
 
     def test_indexing_with_unicode(self):
         """Test unicode field values and path components."""
         unicode_name = u'Jöe Téster'
         unicode_id = u'smöö'
         result = self.conn.index('test-index', 'test-type', {'name': unicode_name}, id=unicode_id)
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': unicode_id, 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': unicode_id, '_index': 'test-index'})
 
         # Make sure it comes back out intact:
         result = self.conn.get('test-index', 'test-type', unicode_id)
@@ -44,13 +44,13 @@ class IndexingTestCase(ElasticSearchTestCase):
 
     def test_quoted_chars_in_id(self):
         result = self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id="""<>?,./`~!@#$%^&*()_+=[]\{{}|:";'""")
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': """<>?,./`~!@#$%^&*()_+=[]\{{}|:";'""", 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': """<>?,./`~!@#$%^&*()_+=[]\{{}|:";'""", '_index': 'test-index'})
 
     def test_indexing_without_id(self):
         result = self.conn.index(
             'test-index', 'test-type', {'name': 'Joe Tester'})
         self.assert_result_contains(result,
-            {'_type': 'test-type', 'ok': True, '_index': 'test-index'})
+            {'_type': 'test-type', '_index': 'test-index'})
         # should have an id of some value assigned.
         ok_('_id' in result and result['_id'])
         # should not generate the same id twice
@@ -60,7 +60,7 @@ class IndexingTestCase(ElasticSearchTestCase):
 
     def test_explicit_index_create(self):
         result = self.conn.create_index('test-index')
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_close_index(self):
         """Make sure a close_index call on an open index reports success."""
@@ -68,7 +68,7 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.health('text-index', wait_for_status='yellow', timeout=1)
 
         result = self.conn.close_index('test-index')
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_open_index(self):
         """Make sure an open_index call on a closed index reports success."""
@@ -77,7 +77,7 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.close_index('test-index')
 
         result = self.conn.open_index('test-index')
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_get_settings(self):
         self.conn.create_index('test-index')
@@ -121,13 +121,13 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
         self.conn.refresh(['test-index'])
         result = self.conn.delete('test-index', 'test-type', 1)
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': '1', '_index': 'test-index'})
 
     def test_delete_by_0_id(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=0)
         self.conn.refresh(['test-index'])
         result = self.conn.delete('test-index', 'test-type', 0)
-        self.assert_result_contains(result, {'_type': 'test-type', '_id': '0', 'ok': True, '_index': 'test-index'})
+        self.assert_result_contains(result, {'_type': 'test-type', '_id': '0', '_index': 'test-index'})
 
     def test_delete_by_id_without_id(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
@@ -141,7 +141,7 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
         self.conn.refresh(["test-index"])
         result = self.conn.delete_all("test-index", "test-type")
-        self.assert_result_contains(result, {'ok': True})
+        self.assert_result_contains(result, {u'acknowledged': True})
 
     def test_delete_by_query(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Tester'}, id=1)
@@ -163,7 +163,7 @@ class IndexingTestCase(ElasticSearchTestCase):
     def test_delete_index(self):
         self.conn.create_index('another-index')
         result = self.conn.delete_index('another-index')
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_delete_nonexistent_index(self):
         """
@@ -183,7 +183,7 @@ class IndexingTestCase(ElasticSearchTestCase):
     def test_put_mapping(self):
         result = self.conn.create_index('test-index')
         result = self.conn.put_mapping('test-index', 'test-type', {'test-type': {'properties': {'name': {'type': 'string', 'store': 'yes'}}}})
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_get_mapping(self):
         result = self.conn.create_index('test-index')
@@ -191,32 +191,47 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.put_mapping('test-index', 'test-type', mapping)
 
         result = self.conn.get_mapping(index=['test-index'], doc_type=['test-type'])
-        eq_(result, {'test-type': {'properties': {'name': {'type': 'string', 'store': True}}}})
+        eq_one_of(
+            lambda: result == {'test-type': {'properties': {'name': {'type': 'string', 'store': True}}}},  # ES 0.90,
+            lambda: result == {u'test-index': {u'mappings': {u'test-type': {u'properties': {u'name': {u'type': u'string', u'store': True}}}}}}  # ES 1.0+
+        )
 
     def test_index_status(self):
         self.conn.create_index('another-index')
         result = self.conn.status('another-index')
         self.conn.delete_index('another-index')
         ok_('indices' in result)
-        self.assert_result_contains(result, {'ok': True})
+        eq_one_of(
+            lambda: result['ok'] == True,  # ES 0.90
+            lambda: result['_shards']['failed'] == 0  # ES 1.0+
+        )
 
     def test_index_flush(self):
         self.conn.create_index('another-index')
         result = self.conn.flush('another-index')
         self.conn.delete_index('another-index')
-        self.assert_result_contains(result, {'ok': True})
+        eq_one_of(
+            lambda: result['ok'] == True,  # ES 0.90
+            lambda: result['_shards']['failed'] == 0  # ES 1.0+
+        )
 
     def test_index_refresh(self):
         self.conn.create_index('another-index')
         result = self.conn.refresh('another-index')
         self.conn.delete_index('another-index')
-        self.assert_result_contains(result, {'ok': True})
+        eq_one_of(
+            lambda: result['ok'] == True,  # ES 0.90
+            lambda: result['_shards']['failed'] == 0  # ES 1.0+
+        )
 
     def test_index_optimize(self):
         self.conn.create_index('another-index')
         result = self.conn.optimize('another-index')
         self.conn.delete_index('another-index')
-        self.assert_result_contains(result, {'ok': True})
+        eq_one_of(
+            lambda: result['ok'] == True,  # ES 0.90
+            lambda: result['_shards']['failed'] == 0  # ES 1.0+
+        )
 
     def test_bulk_index(self):
         # Try counting the docs in a nonexistent index:
@@ -228,8 +243,14 @@ class IndexingTestCase(ElasticSearchTestCase):
         ]
         result = self.conn.bulk_index('test-index', 'test-type', docs)
         eq_(len(result['items']), 2)
-        eq_(result['items'][0]['create']['ok'], True)
-        eq_(result['items'][1]['index']['ok'], True)
+        eq_one_of(
+            lambda: result['items'][0]['create']['ok'] == True, # ES < 1.0
+            lambda: result['items'][0]['create']['status'] == 201  # ES >= 1.0
+        )
+        eq_one_of(
+            lambda: result['items'][1]['index']['ok'] == True,  # ES < 1.0
+            lambda: result['items'][1]['index']['status'] == 201  # ES >= 1.0
+        )
         eq_(result['items'][1]['index']['_id'], '303')
         self.conn.refresh()
         eq_(self.conn.count('*:*',
@@ -270,7 +291,7 @@ class IndexingTestCase(ElasticSearchTestCase):
             ]
         }
         result = self.conn.update_aliases(settings)
-        self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
+        self.assert_result_contains(result, {'acknowledged': True})
 
     def test_alias_nonexistent_index(self):
         settings = {
@@ -349,15 +370,24 @@ class SearchTestCase(ElasticSearchTestCase):
 
     def test_multi_get_simple(self):
         result = self.conn.multi_get([1], index='test-index', doc_type='test-type')
-        self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]})
+        eq_one_of(
+            lambda: self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]}),  # ES 0.90
+            lambda: {u'docs': [{u'_type': u'test-type', u'_source': {u'name': u'Joe Tester'}, u'_index': u'test-index', u'_version': 1, u'found': True, u'_id': u'1'}]}  # ES 1.0+
+        )
 
     def test_multi_get_mix(self):
         result = self.conn.multi_get([{'_type': 'test-type', '_id': 1}], index='test-index')
-        self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]})
+        eq_one_of(
+            lambda: self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]}),  # ES 0.90
+            lambda: self.assert_result_contains(result, {u'docs': [{u'_type': u'test-type', u'_source': {u'name': u'Joe Tester'}, u'_index': u'test-index', u'_version': 1, u'found': True, u'_id': u'1'}]})  # ES 1.0+
+        )
 
     def test_multi_get_custom(self):
         result = self.conn.multi_get([{'_type': 'test-type', '_id': 1, 'fields': ['name'], '_index': 'test-index'}])
-        self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', 'fields': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]})
+        eq_one_of(
+            lambda: self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', 'fields': {'name': 'Joe Tester'}, '_index': 'test-index', "_version": 1, "exists": True}]}),  # ES 0.90
+            lambda: self.assert_result_contains(result, {'docs': [{'_type': 'test-type', '_id': '1', 'fields': {'name': ['Joe Tester']}, '_index': 'test-index', "_version": 1, "found": True}]})  # ES 1.0+
+        )
 
     def test_get_count_by_search(self):
         result = self.conn.count('name:joe', index='test-index')

--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -9,7 +9,7 @@ import six
 
 # Test that __all__ is sufficient:
 from pyelasticsearch import *
-from pyelasticsearch.tests import ElasticSearchTestCase
+from pyelasticsearch.tests import ElasticSearchTestCase, WHATEVER
 
 
 class IndexingTestCase(ElasticSearchTestCase):
@@ -365,7 +365,7 @@ class SearchTestCase(ElasticSearchTestCase):
 
     def test_search_by_field(self):
         result = self.conn.search('name:joe', index='test-index')
-        self.assert_result_contains(result, {'hits': {'hits': [{'_score': 0.19178301, '_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'}], 'total': 1, 'max_score': 0.19178301}})
+        self.assert_result_contains(result, {'hits': {'hits': [{'_score': WHATEVER, '_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'}], 'total': 1, 'max_score': WHATEVER}})
 
     def test_search_string_paginated(self):
         with patch.object(self.conn, 'send_request') as send_request:
@@ -405,7 +405,7 @@ class SearchTestCase(ElasticSearchTestCase):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Test'}, id=3)
         self.conn.refresh(['test-index'])
         result = self.conn.more_like_this('test-index', 'test-type', 1, ['name'], min_term_freq=1, min_doc_freq=1)
-        self.assert_result_contains(result, {'hits': {'hits': [{'_score': 0.19178301, '_type': 'test-type', '_id': '3', '_source': {'name': 'Joe Test'}, '_index': 'test-index'}], 'total': 1, 'max_score': 0.19178301}})
+        self.assert_result_contains(result, {'hits': {'hits': [{'_score': WHATEVER, '_type': 'test-type', '_id': '3', '_source': {'name': 'Joe Test'}, '_index': 'test-index'}], 'total': 1, 'max_score': WHATEVER}})
 
     def test_mlt_with_body(self):
         self.conn.index('test-index', 'test-type', {'name': 'Joe Test', 'age': 22}, id=2)
@@ -427,7 +427,7 @@ class SearchTestCase(ElasticSearchTestCase):
             }
         result = self.conn.more_like_this('test-index', 'test-type', 1, ['name'], body=body, min_term_freq=1, min_doc_freq=1)
         self.assert_result_contains(result,
-                {'hits': {'hits': [{'_score': 0.19178301, '_type': 'test-type', '_id': '3', '_source': {'age': 16, 'name': 'Joe Justin'}, '_index': 'test-index'}], 'total': 1, 'max_score': 0.19178301}})
+                {'hits': {'hits': [{'_score': WHATEVER, '_type': 'test-type', '_id': '3', '_source': {'age': 16, 'name': 'Joe Justin'}, '_index': 'test-index'}], 'total': 1, 'max_score': WHATEVER}})
 
     def test_mlt_fields(self):
         self.conn.index('test-index', 'test-type', {'name': 'Angus', 'sport': 'football'}, id=3)
@@ -438,7 +438,7 @@ class SearchTestCase(ElasticSearchTestCase):
 
         result = self.conn.more_like_this('test-index', 'test-type', 3, ['sport'], min_term_freq=1, min_doc_freq=1)
         self.assert_result_contains(result,
-                {u'hits': {u'hits': [{u'_score': 0.30685282, u'_type': u'test-type', u'_id': u'4', u'_source': {u'sport': u'football', u'name': u'Cam'}, u'_index': u'test-index'}], u'total': 1, u'max_score': 0.30685282}})
+                {u'hits': {u'hits': [{u'_score': WHATEVER, u'_type': u'test-type', u'_id': u'4', u'_source': {u'sport': u'football', u'name': u'Cam'}, u'_index': u'test-index'}], u'total': 1, u'max_score': WHATEVER}})
 
 
 class DangerousOperationTests(ElasticSearchTestCase):

--- a/pyelasticsearch/tests/client_tests.py
+++ b/pyelasticsearch/tests/client_tests.py
@@ -65,13 +65,17 @@ class IndexingTestCase(ElasticSearchTestCase):
     def test_close_index(self):
         """Make sure a close_index call on an open index reports success."""
         self.conn.create_index('test-index')
+        self.conn.health('text-index', wait_for_status='yellow', timeout=1)
+
         result = self.conn.close_index('test-index')
         self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
 
     def test_open_index(self):
         """Make sure an open_index call on a closed index reports success."""
         self.conn.create_index('test-index')
+        self.conn.health('text-index', wait_for_status='yellow', timeout=1)
         self.conn.close_index('test-index')
+
         result = self.conn.open_index('test-index')
         self.assert_result_contains(result, {'acknowledged': True, 'ok': True})
 


### PR DESCRIPTION
This fixes three different issues one of which is covered in issue #107. All the tests now pass with Elasticsearch 0.90 up through 1.3 except three tests which fail because the relevant ElasticSearch client methods are broken with Elasticsearch 1.0+. Those are covered in other issues.

r?