### PR TITLE
Make sure the Content-Length header gets set when calling `create_index(...

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,9 +2,15 @@
 Changelog
 =========
 
-v1.2
-----
+v1.2 (2015-03-06)
+-----------------
+* Make sure the Content-Length header gets set when calling ``create_index()``
+  with no explicit ``settings`` arg. This solves 411s when using nginx as a
+  proxy.
 * Add ``doc_as_upsert()`` arg to ``update()``.
+* Make ``bulk_chunks()`` compute perfectly optimal results, no longer ever
+  exceeding the byte limit unless a single document is over the limit on its own.
+
 
 v1.1 (2015-02-12)
 -----------------

--- a/pyelasticsearch/__init__.py
+++ b/pyelasticsearch/__init__.py
@@ -14,7 +14,7 @@ __author__ = 'Erik Rose'
 __all__ = ['ElasticSearch', 'ElasticHttpError', 'Timeout', 'ConnectionError',
            'ElasticHttpNotFoundError', 'IndexAlreadyExistsError', 'BulkError',
            'InvalidJsonResponseError', 'bulk_chunks']
-__version__ = '1.1'
+__version__ = '1.2'
 __version_info__ = tuple(__version__.split('.'))
 
 get_version = lambda: __version_info__

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -998,7 +998,7 @@ class ElasticSearch(object):
         .. _`ES's create-index API`:
             http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index.html
         """
-        return self.send_request('PUT', [index], body=settings,
+        return self.send_request('PUT', [index], body=settings or {},
                                  query_params=query_params)
 
     @es_kwargs()


### PR DESCRIPTION
...)`  with no explicit `settings` arg. Fix #166. Bump version to 1.2.