### PR TITLE
Trying with 'latin1' in _encode_json for UnicodeDecodeErrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 .idea
 .*.swp
 __pycache__/
+*~

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Daniel Lindsley
 Dave Dash
 Detonavomek
 Erik Rose
+Félix Brezo
 Gavin Carothers
 Hanno Schlichting
 Honza Kral
@@ -26,3 +27,4 @@ Roberto Ur
 Sundar Raman
 Szymon Teżewski
 Will Kahn-Greene
+Yaiza Rubio

--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -302,8 +302,13 @@ class ElasticSearch(object):
         """
         Convert a Python value to a form suitable for ElasticSearch's JSON DSL.
         """
-        return json.dumps(value, cls=self.json_encoder, use_decimal=True)
-
+        try:
+            return json.dumps(value, cls=self.json_encoder, use_decimal=True)
+        except:
+            # Trying with 'latin1' when UnicodeDecodeErrors take place. Just a bypass:
+            #   UnicodeDecodeError: 'utf8' codec can't decode bytes in position XX-XX: invalid continuation byte
+            return json.dumps(value, cls=self.json_encoder, use_decimal=True, encoding='latin1')
+            
     ## REST API
 
     @es_kwargs('routing', 'parent', 'timestamp', 'ttl', 'percolate',


### PR DESCRIPTION
The _encode_json now does not break the entire process but default, but gives it a new try with a new encoding 'latin1'.