### PR TITLE
Raise proper error when index already exists

### DIFF
--- a/pyelasticsearch/client.py
+++ b/pyelasticsearch/client.py
@@ -293,6 +293,7 @@ class ElasticSearch(object):
             error_class = ElasticHttpNotFoundError
         elif (hasattr(error_message, 'startswith') and
               (error_message.startswith('IndexAlreadyExistsException') or
+               error_message.startswith('index_already_exists_exception') or
                'nested: IndexAlreadyExistsException' in error_message)):
             error_class = IndexAlreadyExistsError
 


### PR DESCRIPTION
Fixes issue #187. The error message is `index_already_exists_exception`.

[Relevant test](https://github.com/pyelasticsearch/pyelasticsearch/blob/master/pyelasticsearch/tests/client_tests.py#L175) was failing, now passing.