### PR TITLE
Add support for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: python
 
-services:
-  - elasticsearch
+env:
+  - ESEARCH_VERSION=1.7.4 ESEARCH_PATH=.
+
+# wait for elastic search start
+before_script:
+  - sleep 10
 
 python:
-  - 2.6
   - 2.7
   - 3.3
+  - 3.4
+  - 3.6
   - pypy
 
 install:
   - pip install .
+  - sh esearch.service install
 
-script: python setup.py test
+script:
+  - sh esearch.service start
+  - python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include README.rst
 include AUTHORS
 include tox.ini
+include requirements.txt
 include docs/Makefile
 include docs/make.bat
 include docs/source/*.rst

--- a/esearch.service
+++ b/esearch.service
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+ESEARCH_DEFAULT_PATH=$(pwd)/.elasticsearch
+ESEARCH_DEFAULT_VERSION="1.7.4"
+
+ESEARCH_PATH=${ESEARCH_PATH:-$ESEARCH_DEFAULT_PATH}
+ESEARCH_VERSION=${ESEARCH_VERSION:-$ESEARCH_DEFAULT_VERSION}
+ESEARCH_BOOT_WAIT=10
+ESEARCH_REPOSITORY=https://download.elastic.co/elasticsearch/elasticsearch
+
+esearch_install() {
+    local _version="${1:-$ESEARCH_VERSION}"
+
+    if test ! -e "$ESEARCH_PATH/elasticsearch-$_version"; then
+        echo "Install elasticsearch $_version to $ESEARCH_PATH..."
+        mkdir -p $ESEARCH_PATH
+        (cd "$ESEARCH_PATH" && curl "$ESEARCH_REPOSITORY/elasticsearch-$_version.tar.gz" -#|tar xz);
+    else
+        echo "Elasticsearch $_version already installed..."
+    fi
+}
+
+esearch_start() {
+    local _version="${1:-$ESEARCH_VERSION}"
+
+    if test -e "$ESEARCH_PATH/.esearch.pid"; then
+        echo "Elasticsearch server is already running..."
+        return
+    fi
+
+    if test -e "$ESEARCH_PATH/elasticsearch-$_version"; then
+        echo "Run elasticsearch $_version ($ESEARCH_PATH/.esearch.pid)...\n"
+        echo $ESEARCH_PATH/elasticsearch-$_version/bin/elasticsearch
+        $ESEARCH_PATH/elasticsearch-$_version/bin/elasticsearch & echo $! > $ESEARCH_PATH/.esearch.pid;
+        sleep $ESEARCH_BOOT_WAIT;
+    else
+        echo "No such elasticsearch server $_version available..."
+        exit 1;
+    fi
+}
+
+esearch_stop() {
+    local _pidfile=$ESEARCH_PATH/.esearch.pid
+
+    if test -e $_pidfile; then
+        local _pid=$(cat "$_pidfile")
+        echo "Shutdown elasticsearch server (PID=$_pid)..."
+        (kill -9 $_pid)
+        rm $_pidfile;
+    else
+        echo "Elasticsearch server is not running"
+    fi
+}
+
+case $1 in
+    start)
+        esearch_start $2;;
+    stop)
+        esearch_stop;;
+    restart)
+        (esearch_stop)
+        esearch_start $2;;
+    install)
+        esearch_install $2;;
+    *)
+        echo "esearch.service [start|stop|restart|install] [version]";;
+esac

--- a/pyelasticsearch/exceptions.py
+++ b/pyelasticsearch/exceptions.py
@@ -1,4 +1,9 @@
-from urllib3.exceptions import TimeoutError as Timeout, ConnectionError
+from urllib3.exceptions import TimeoutError as Timeout
+
+try:
+    from urllib3.exceptions import NewConnectionError as ConnectionError
+except ImportError:
+    from urllib3.exceptions import ConnectionError
 
 
 class ElasticHttpError(Exception):

--- a/pyelasticsearch/tests/__init__.py
+++ b/pyelasticsearch/tests/__init__.py
@@ -5,30 +5,24 @@ These require a local elasticsearch server running on the default port
 (localhost:9200).
 """
 from time import sleep
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 
-from nose import SkipTest
-from nose.tools import eq_
 from six.moves import xrange
 
 # Test that __all__ is sufficient:
 from pyelasticsearch import *
 
 
-def setUp():
-    """When loading the test package, wait for ES to come up."""
-    for _ in xrange(200):
-        try:
-            ElasticSearch().health(wait_for_status='yellow')
-            return
-        except ConnectionError:
-            sleep(.1)
-    raise SkipTest('Could not connect to the ES server.')
-
-
 class ElasticSearchTestCase(TestCase):
-    def setUp(self):
-        self.conn = ElasticSearch()
+    @classmethod
+    def setUpClass(cls):
+        """When loading the test package, wait for ES to come up."""
+        cls.conn = ElasticSearch()
+
+        try:
+            cls.conn.health(wait_for_status='yellow', timeout=10)
+        except ConnectionError:
+            raise SkipTest('Could not connect to the ES server.')
 
     def tearDown(self):
         try:
@@ -38,5 +32,5 @@ class ElasticSearchTestCase(TestCase):
 
     def assert_result_contains(self, result, expected):
         for (key, value) in expected.items():
-            eq_(value, result[key])
+            self.assertEqual(value, result[key])
         return True

--- a/pyelasticsearch/tests/es_kwargs_tests.py
+++ b/pyelasticsearch/tests/es_kwargs_tests.py
@@ -1,10 +1,12 @@
 from datetime import datetime, date
 import unittest
 
-from mock import patch
-from nose import SkipTest
-from nose.tools import eq_, ok_, assert_raises
 from six import PY3, b
+
+if PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 # Test that __all__ is sufficient:
 from pyelasticsearch import *
@@ -17,20 +19,20 @@ class KwargsForQueryTests(unittest.TestCase):
     def test_to_query(self):
         """Test the thing that translates objects to query string text."""
         to_query = ElasticSearch('http://localhost:9200/')._to_query
-        eq_(to_query(4), '4')
-        eq_(to_query(4.5), '4.5')
-        eq_(to_query(True), 'true')
-        eq_(to_query(('4', 'hi', 'thomas')), '4,hi,thomas')
-        eq_(to_query(datetime(2000, 1, 2, 12, 34, 56)),
+        self.assertEqual(to_query(4), '4')
+        self.assertEqual(to_query(4.5), '4.5')
+        self.assertEqual(to_query(True), 'true')
+        self.assertEqual(to_query(('4', 'hi', 'thomas')), '4,hi,thomas')
+        self.assertEqual(to_query(datetime(2000, 1, 2, 12, 34, 56)),
                          '2000-01-02T12:34:56')
-        eq_(to_query(date(2000, 1, 2)),
+        self.assertEqual(to_query(date(2000, 1, 2)),
                          '2000-01-02T00:00:00')
-        assert_raises(TypeError, to_query, object())
+        with self.assertRaises(TypeError):
+            to_query(object())
 
         # do not use unittest.skipIf because of python 2.6
         if not PY3:
-            eq_(to_query(long(4)), '4')
-
+            self.assertEqual(to_query(long(4)), '4')
 
     def test_es_kwargs(self):
         """
@@ -46,9 +48,9 @@ class KwargsForQueryTests(unittest.TestCase):
         """
             return doc, query_params, other_kwarg
 
-        eq_(index(3, refresh=True, es_timeout=7, other_kwarg=1),
+        self.assertEqual(index(3, refresh=True, es_timeout=7, other_kwarg=1),
                          (3, {'refresh': True, 'timeout': 7}, 1))
-        eq_(index.__name__, 'index')
+        self.assertEqual(index.__name__, 'index')
 
     def test_index(self):
         """Integration-test ``index()`` with some decorator-handled arg."""
@@ -69,13 +71,13 @@ class KwargsForQueryTests(unittest.TestCase):
 
         ((_, url), kwargs) = perform.call_args
 
-        eq_(url, '/some_index/some_type/3')
+        self.assertEqual(url, '/some_index/some_type/3')
 
         # Make sure stringification happened, url encoding didn't, and es_
         # prefixes got stripped:
-        eq_(kwargs['params'], {'routing': b('boogie'),
-                               'snorkfest': b('true'),  # We must do stringifying.
-                               'borkfest': b('gerbils:great')})  # Urllib3HttpConnection does url escaping.
+        self.assertEqual(kwargs['params'], {'routing': b('boogie'),
+                                            'snorkfest': b('true'),  # We must do stringifying.
+                                            'borkfest': b('gerbils:great')})  # Urllib3HttpConnection does url escaping.
 
     def test_arg_cross_refs_with_trailing(self):
         """
@@ -95,11 +97,11 @@ class KwargsForQueryTests(unittest.TestCase):
         """
 
         if some_method.__doc__ is None:
-            raise SkipTest("This test doesn't work under python -OO.")
+            raise unittest.SkipTest("This test doesn't work under python -OO.")
 
         # Make sure it adds (only) the undocumented args and preserves anything
         # that comes after the args block:
-        eq_(
+        self.assertEqual(
             some_method.__doc__,
             """
         Do stuff.
@@ -125,9 +127,9 @@ class KwargsForQueryTests(unittest.TestCase):
         """
 
         if some_method.__doc__ is None:
-            raise SkipTest("This test doesn't work under python -OO.")
+            raise unittest.SkipTest("This test doesn't work under python -OO.")
 
-        eq_(
+        self.assertEqual(
             some_method.__doc__,
             """
         Do stuff.

--- a/pyelasticsearch/tests/json_tests.py
+++ b/pyelasticsearch/tests/json_tests.py
@@ -2,8 +2,6 @@
 from datetime import datetime, date
 from decimal import Decimal
 
-from nose.tools import eq_, assert_raises
-
 from pyelasticsearch.tests import ElasticSearchTestCase
 
 
@@ -15,37 +13,38 @@ class JsonTests(ElasticSearchTestCase):
         up with quotes around them, which would suggest to ES to represent them
         as strings if inferring a mapping."""
         ones = '1.111111111111111111'
-        eq_(self.conn._encode_json({'hi': Decimal(ones)}),
+        self.assertEqual(self.conn._encode_json({'hi': Decimal(ones)}),
                          '{"hi": %s}' % ones)
 
     def test_set_encoding(self):
         """Make sure encountering a set doesn't raise a circular reference
         error."""
-        eq_(self.conn._encode_json({'hi': set([1])}),
+        self.assertEqual(self.conn._encode_json({'hi': set([1])}),
                          '{"hi": [1]}')
 
     def test_tuple_encoding(self):
         """Make sure tuples encode as lists."""
-        eq_(self.conn._encode_json({'hi': (1, 2, 3)}),
+        self.assertEqual(self.conn._encode_json({'hi': (1, 2, 3)}),
                          '{"hi": [1, 2, 3]}')
 
     def test_unhandled_encoding(self):
         """Make sure we raise a TypeError when encoding an unsupported type."""
-        assert_raises(TypeError, self.conn._encode_json, object())
+        with self.assertRaises(TypeError):
+            self.conn._encode_json(object())
 
     def test_encoding(self):
         """Test encoding a zillion other types."""
-        eq_(self.conn._encode_json('abc'), u'"abc"')
-        eq_(self.conn._encode_json(u'☃'), r'"\u2603"')
-        eq_(self.conn._encode_json(123), '123')
-        eq_(self.conn._encode_json(12.25), '12.25')
-        eq_(self.conn._encode_json(True), 'true')
-        eq_(self.conn._encode_json(False), 'false')
-        eq_(self.conn._encode_json(
+        self.assertEqual(self.conn._encode_json('abc'), u'"abc"')
+        self.assertEqual(self.conn._encode_json(u'☃'), r'"\u2603"')
+        self.assertEqual(self.conn._encode_json(123), '123')
+        self.assertEqual(self.conn._encode_json(12.25), '12.25')
+        self.assertEqual(self.conn._encode_json(True), 'true')
+        self.assertEqual(self.conn._encode_json(False), 'false')
+        self.assertEqual(self.conn._encode_json(
             date(2011, 12, 30)),
             '"2011-12-30T00:00:00"')
-        eq_(self.conn._encode_json(
+        self.assertEqual(self.conn._encode_json(
             datetime(2011, 12, 30, 11, 59, 32)),
             '"2011-12-30T11:59:32"')
-        eq_(self.conn._encode_json([1, 2, 3]), '[1, 2, 3]')
-        eq_(self.conn._encode_json({'a': 1}), '{"a": 1}')
+        self.assertEqual(self.conn._encode_json([1, 2, 3]), '[1, 2, 3]')
+        self.assertEqual(self.conn._encode_json({'a': 1}), '{"a": 1}')

--- a/pyelasticsearch/tests/utils_tests.py
+++ b/pyelasticsearch/tests/utils_tests.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-from nose.tools import eq_
 from six.moves import xrange
 
 from pyelasticsearch import bulk_chunks
@@ -17,25 +16,25 @@ class BulkChunksTests(TestCase):
         """Make sure action iterators shorter than 1 chunk work."""
         actions = self.str_xrange(1)  # just 0
         chunks = bulk_chunks(actions, docs_per_chunk=2)
-        eq_(list(chunks), [['0']])
+        self.assertEqual(list(chunks), [['0']])
 
     def test_over(self):
         """Make sure action iterators longer than 1 chunk work."""
         actions = self.str_xrange(7)
         chunks = bulk_chunks(actions, docs_per_chunk=3)
-        eq_(list(chunks), [['0', '1', '2'], ['3', '4', '5'], ['6']])
+        self.assertEqual(list(chunks), [['0', '1', '2'], ['3', '4', '5'], ['6']])
 
     def test_on(self):
         """Make sure action iterators that end on a chunk boundary work."""
         actions = self.str_xrange(4)
         chunks = bulk_chunks(actions, docs_per_chunk=2)
-        eq_(list(chunks), [['0', '1'], ['2', '3']])
+        self.assertEqual(list(chunks), [['0', '1'], ['2', '3']])
 
     def test_none(self):
         """Make sure empty action iterators work."""
         actions = self.str_xrange(0)
         chunks = bulk_chunks(actions, docs_per_chunk=2)
-        eq_(list(chunks), [])
+        self.assertEqual(list(chunks), [])
 
     def test_bytes(self):
         """
@@ -45,7 +44,7 @@ class BulkChunksTests(TestCase):
         """
         actions = ['o', 'hi', 'good', 'chimpanzees']
         chunks = bulk_chunks(actions, bytes_per_chunk=5)
-        eq_(list(chunks), [['o', 'hi'], ['good'], ['chimpanzees']])
+        self.assertEqual(list(chunks), [['o', 'hi'], ['good'], ['chimpanzees']])
 
     def test_bytes_first_too_big(self):
         """
@@ -54,4 +53,4 @@ class BulkChunksTests(TestCase):
         """
         actions = ['chimpanzees', 'hi', 'ho']
         chunks = bulk_chunks(actions, bytes_per_chunk=6)
-        eq_(list(chunks), [['chimpanzees'], ['hi', 'ho']])
+        self.assertEqual(list(chunks), [['chimpanzees'], ['hi', 'ho']])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi
+elasticsearch>=1.3.0,<2.0.0
+urllib3>=1.8,<2.0
+simplejson>=3.0
+six>=1.4.0,<2.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 
 import codecs
 import re
+from six import PY2
+
 from os.path import join, dirname
 
 # Prevent spurious errors during `python setup.py test`, a la
@@ -46,6 +48,11 @@ def find_version(file_path):
     raise RuntimeError('Unable to find version string.')
 
 
+def install_requirements(file_path):
+    with open(file_path, 'r') as reqs:
+        return [line for line in (l.strip() for l in reqs) if line]
+
+
 setup(
     name='pyelasticsearch',
     version=find_version(join('pyelasticsearch', '__init__.py')),
@@ -69,22 +76,16 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         # simplejson doesn't support 3.1 or 3.2.
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
     ],
-    install_requires=[
-        'certifi',
-        'elasticsearch>=1.3.0,<2.0.0',
-        'urllib3>=1.8,<2.0',
-        'simplejson>=3.0',
-        'six>=1.4.0,<2.0'
-    ],
-    tests_require=['mock', 'nose>=1.2.1'],
-    test_suite='nose.collector',
+    install_requires=install_requirements('requirements.txt'),
+    tests_require=['mock'] if PY2 else [],
+    test_suite='pyelasticsearch.tests',
     url='https://github.com/pyelasticsearch/pyelasticsearch'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,21 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py27, py33, py34, py36, pypy
 
 [testenv]
-commands = python setup.py test
+setenv =
+    ESEARCH_VERSION=1.7.4
+    ESEARCH_PATH={toxworkdir}
+whitelist_externals =
+    sh
+deps =
+    -rrequirements.txt
+commands =
+    sh esearch.service install
+    sh esearch.service start
+    {envbindir}/python setup.py test
+    sh esearch.service stop
 
 [pytest]
 python_files = *_tests.py


### PR DESCRIPTION
- Fix tox & travis targets.
- Force elasticsearch server version to 1.5.2 by default
- Drop support for python 2.6
- Fix urllib3>=1.10 api break (raise NewConnectionError instead of ConnectionError)