### PR TITLE
Remove issue with "import six" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import codecs
 import re
-from six import PY2
+import sys
 
 from os.path import join, dirname
 
@@ -14,6 +14,9 @@ except ImportError:
     pass
 
 from setuptools import setup, find_packages
+
+
+PY2 = (sys.version_info < (3,0))
 
 
 def read(filename):


### PR DESCRIPTION
This is caused by the "import six" and the order of install of six dependency. Anyway it was a bad idea, but strangely this works with "pip install pyelasticsearch" (without six installed) and not with "pip install -r".